### PR TITLE
Fix SPM Path configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "NestedPublished",
+            path: "Sources",
             targets: ["NestedPublished"]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,12 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "NestedPublished",
-            path: "Sources",
             targets: ["NestedPublished"]
         ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "NestedPublished", dependencies: []),
+        .target(name: "NestedPublished", dependencies: [], path: "Sources"),
     ]
 )


### PR DESCRIPTION
The Swift Package Manager looked for `Sources/NestedPublished/*.swift`. Needed to add in a path option to override the default location. Works now in Xcode.